### PR TITLE
Net 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,16 @@ classDiagram
     MermaidGraph.NET --> mermaid-graph
     class mermaid-graph{
         type Exe
-        target net9.0
+        target net8.0;net9.0
     }
+    class Nerdbank.GitVersioning{
+        type NuGet
+        version 3.7.115
+    }
+    mermaid-graph ..> Nerdbank.GitVersioning
     class Microsoft.Build{
         type NuGet
-        version 17.13.9
+        version 17.11.4
     }
     mermaid-graph ..> Microsoft.Build
     class Microsoft.Build.Locator{
@@ -63,11 +68,6 @@ classDiagram
         version 1.9.1
     }
     mermaid-graph ..> Microsoft.Build.Locator
-    class Microsoft.Build.Utilities.Core{
-        type NuGet
-        version 17.13.9
-    }
-    mermaid-graph ..> Microsoft.Build.Utilities.Core
     class System.CommandLine.DragonFruit{
         type NuGet
         version 0.4.0-alpha.22272.1
@@ -79,6 +79,11 @@ classDiagram
         target net9.0
     }
     MermaidGraphTests ..> mermaid-graph
+    class Nerdbank.GitVersioning{
+        type NuGet
+        version 3.7.115
+    }
+    MermaidGraphTests ..> Nerdbank.GitVersioning
     class coverlet.collector{
         type NuGet
         version 6.0.4

--- a/mermaid-graph/Diagrams/Base/MermaidDiagram.cs
+++ b/mermaid-graph/Diagrams/Base/MermaidDiagram.cs
@@ -49,7 +49,7 @@ public abstract class MermaidDiagram : IMermaidDiagram
     /// <summary>
     /// Initialize the graph output.
     /// </summary>
-    public virtual void Header(string title)
+    internal virtual void Header(string title)
     {
         Graph.Clear();
         Graph.AppendLine($"""
@@ -67,7 +67,7 @@ public abstract class MermaidDiagram : IMermaidDiagram
     /// Get the mermaid diagram Markdown text.
     /// </summary>
     /// <returns>The contents of the graph buffer.</returns>
-    public override string ToString() => Graph.ToString();
+    public sealed override string ToString() => Graph.ToString();
 
     /// <inheritdoc />
     public virtual string Project(FileInfo file, string? filter = null, bool excludeNuget = false)

--- a/mermaid-graph/Diagrams/ClassDiagram.cs
+++ b/mermaid-graph/Diagrams/ClassDiagram.cs
@@ -10,7 +10,7 @@ namespace MermaidGraph.Diagrams;
 public sealed class ClassDiagram : MermaidDiagram
 {
     /// <inheritdoc />
-    public override void Header(string title)
+    internal override void Header(string title)
     {
         base.Header(title);
         Graph.AppendLine("classDiagram");

--- a/mermaid-graph/Diagrams/ClassDiagram.cs
+++ b/mermaid-graph/Diagrams/ClassDiagram.cs
@@ -61,8 +61,9 @@ public sealed class ClassDiagram : MermaidDiagram
     {
         var projectName = Path.GetFileNameWithoutExtension(project.FullPath);
         var type = project.GetPropertyValue("OutputType");
-        var targetFramework = project.GetPropertyValue("TargetFramework") ?? 
-                              project.GetPropertyValue("TargetFrameworks");
+        var targetFramework = project.GetPropertyValue("TargetFramework");
+        if (string.IsNullOrEmpty(targetFramework)) 
+            targetFramework = project.GetPropertyValue("TargetFrameworks");
 
         Graph.AppendLine($$"""
                               class {{projectName}}{

--- a/mermaid-graph/Diagrams/GraphDiagram.cs
+++ b/mermaid-graph/Diagrams/GraphDiagram.cs
@@ -10,7 +10,7 @@ namespace MermaidGraph.Diagrams;
 public sealed class GraphDiagram : MermaidDiagram
 {
     /// <inheritdoc />
-    public override void Header(string title)
+    internal override void Header(string title)
     {
         base.Header(title);
         Graph.AppendLine("graph TD");

--- a/mermaid-graph/mermaid-graph.csproj
+++ b/mermaid-graph/mermaid-graph.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>MermaidGraph</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.13.9" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build" Version="17.11.4" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
   </ItemGroup>

--- a/mermaid-graphTests/CommandsTests.cs
+++ b/mermaid-graphTests/CommandsTests.cs
@@ -56,6 +56,7 @@ public class CommandsTests
 
         Console.WriteLine(graph);
         Assert.That(graph, Is.Not.Null.Or.Empty, "Graph should not be null or empty.");
+        Assert.That(graph, Does.Contain($"title: {info.Name}"));
         Assert.That(graph, Does.Contain("mermaid-graph"));
         Assert.That(graph, Does.Contain("MermaidGraphTests"));
         var graphType = DetectType(ExtractMermaid(graph));
@@ -74,6 +75,7 @@ public class CommandsTests
         Assert.That(info.Exists);
         var graph = Commands.Project(info, type);
         Assert.That(graph, Is.Not.Null.Or.Empty, "Graph should not be null or empty.");
+        Assert.That(graph, Does.Contain($"title: {info.Name}"));
         Assert.That(graph, Does.Contain("mermaid-graph"));
         Assert.That(graph, Does.Contain("MermaidGraphTests"));
         Console.WriteLine(graph);

--- a/mermaid-graphTests/MermaidDiagramTests.cs
+++ b/mermaid-graphTests/MermaidDiagramTests.cs
@@ -28,22 +28,4 @@ public class MermaidDiagramTests
         Assert.Throws<NotImplementedException>(()=>
             MermaidDiagram.GetDiagramType((DiagramType)999));
     }
-
-    [Test]
-    [TestCase(DiagramType.Class)]
-    [TestCase(DiagramType.Graph)]
-    public void Header_ShouldInitializeGraphWithTitle(DiagramType type)
-    {
-        var diagram = (MermaidDiagram)MermaidDiagram.GetDiagramType(type);
-        
-        // Arrange
-        const string title = "Test Diagram";
-
-        // Act
-        diagram.Header(title);
-
-        // Assert
-        Assert.That(diagram.ToString(), Does.Contain($"title: {title}"));
-    }
 }
-


### PR DESCRIPTION
# Summary of Changes:

- Target Framework Updates:

    Updated the target frameworks from .NET 9.0 to .NET 8.0; .NET 9.0 for broader compatibility.

- Dependency Updates:

    Microsoft.Build: Downgraded from version 17.13.9 to 17.11.4 to support net8.0

- Code Modifications:

    Changed method access modifiers in MermaidDiagram.cs and its derived classes:
        Header method updated from public to internal for more restrictive access.
        Marked ToString method as sealed override to prevent further overrides.
    Refactored logic for determining TargetFramework in ClassDiagram.cs:
        Added fallback to TargetFrameworks when TargetFramework is empty.

- Testing Enhancements:

    Improved test assertions in CommandsTests.cs to validate graph content includes the diagram title.
    Removed redundant test case Header_ShouldInitializeGraphWithTitle from MermaidDiagramTests.cs.

- Documentation Updates:

    Updated README.md to reflect changes in target frameworks and dependencies.

Closes #8 